### PR TITLE
Change when Darkmoon Fair is up based on realm time

### DIFF
--- a/MKPT_Item.lua
+++ b/MKPT_Item.lua
@@ -280,8 +280,16 @@ function MKPT_DarkmoonQuest:GetIcon()
 end
 
 function MKPT_DarkmoonQuest:IsDmfUp()
-  local dayOfWeek = tonumber(date("%w"))
-  local dayOfMonth = tonumber(date("%e"))
+  -- Get current realm time
+  local calendarTime = C_DateAndTime.GetCurrentCalendarTime()
+  
+  -- Sometimes GetCurrentCalendarTime does not register on login
+  if not calendarTime or calendarTime.year == 1999 then
+    return false
+  end
+
+  local dayOfMonth = calendarTime.monthDay
+  local weekday = calendarTime.weekday -- 1=Sunday, 2=Monday, ..., 7=Saturday
 
   local firstSundayOfMonth = ((dayOfMonth - (dayOfWeek + 1)) % 7) + 1
   local daysSinceFirstSunday = dayOfMonth - firstSundayOfMonth

--- a/MKPT_Item.lua
+++ b/MKPT_Item.lua
@@ -288,8 +288,8 @@ function MKPT_DarkmoonQuest:IsDmfUp()
     return false
   end
 
+  local dayOfWeek = calendarTime.weekday
   local dayOfMonth = calendarTime.monthDay
-  local weekday = calendarTime.weekday -- 1=Sunday, 2=Monday, ..., 7=Saturday
 
   local firstSundayOfMonth = ((dayOfMonth - (dayOfWeek + 1)) % 7) + 1
   local daysSinceFirstSunday = dayOfMonth - firstSundayOfMonth


### PR DESCRIPTION
This changes the Darkmoon Fair is up check from local time to realm time. However, there are reports of this function not working on initial login but should correct itself on a refresh.
https://warcraft.wiki.gg/wiki/Talk%3AAPI_C_DateAndTime.GetCurrentCalendarTime